### PR TITLE
add dockerfile and readme section

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu
+RUN mkdir -p /opt/statusengine/worker
+RUN echo "America/New_York" > /etc/timezone 
+RUN apt-get update && apt-get install tzdata && dpkg-reconfigure -f noninteractive tzdata
+RUN   apt-get install -y git php-cli php-zip php-redis redis-server php-mysql php-json php-gearman php-bcmath php-mbstring unzip wget
+RUN  wget https://getcomposer.org/installer && chmod +x installer && php ./installer --install-dir=bin --filename=composer
+WORKDIR /opt/statusengine/worker/
+COPY . /opt/statusengine/worker/
+RUN chmod +x bin/* && composer install
+RUN cp etc/config.yml.example etc/config.yml
+CMD [ "/opt/statusengine/worker/bin/StatusengineWorker.php" ]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ chmod +x worker/bin/*
 composer install
 ````
 
+## Docker
+* Have gearman, mysql, redis all up and running
+* Follow the official install guide's section on setting up mysql
+* Build the Docker container; this will pull in the example config file from etc/config.yml.example.
+* Run the docker container. You may also override the config file built into the container using the -v flag, like so: `docker run -v /path/config.yml:/opt/statusengine/worker/etc/config.yml <other arguments>`
+
 ## Config
 ````
 cp worker/etc/config.yml.example worker/etc/config.yml
@@ -43,7 +49,7 @@ php bin/Console.php cluster add --nodename NODENAME
 /opt/statusengine/worker/bin/StatusengineWorker.php
 ````
 
-## Proxy warnign
+## Proxy warning
 If you are behind a proxy, set `no_proxy=127.0.0.1,localhost` in your `/etc/environment`!
 
 ## Statusengine statistics


### PR DESCRIPTION
added dockerfile to project; this assumes the user already has the other dependencies (mysql, etc.) working. It pulls in the example config file and starts the application. Addresses part of #13 