### PR TITLE
Add character set detection for non utf8 chars in JSON

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,8 @@
     "ext-gearman": "*",
     "ext-mbstring": "*",
     "ext-bcmath": "*",
+    "ext-json": "*",
+    "ext-iconv": "*",
     "symfony/yaml": "2.8",
     "symfony/console": "2.8",
     "crate/crate-dbal":"*",

--- a/src/Childs/HostcheckChild.php
+++ b/src/Childs/HostcheckChild.php
@@ -99,7 +99,7 @@ class HostcheckChild extends Child {
 
         $this->SignalHandler->bind();
 
-        $this->QueueingEngine = new QueueingEngine($this->Config, $this->HostcheckConfig);
+        $this->QueueingEngine = new QueueingEngine($this->Config, $this->HostcheckConfig, $this->Syslog);
         $this->Queue = $this->QueueingEngine->getQueue();
         $this->Queue->connect();
     }

--- a/src/Childs/HoststatusChild.php
+++ b/src/Childs/HoststatusChild.php
@@ -128,7 +128,7 @@ class HoststatusChild extends Child {
 
         $this->SignalHandler->bind();
 
-        $this->QueueingEngine = new QueueingEngine($this->Config, $this->HoststatusConfig);
+        $this->QueueingEngine = new QueueingEngine($this->Config, $this->HoststatusConfig, $this->Syslog);
         $this->Queue = $this->QueueingEngine->getQueue();
         $this->Queue->connect();
 

--- a/src/Childs/LogentryChild.php
+++ b/src/Childs/LogentryChild.php
@@ -100,7 +100,7 @@ class LogentryChild extends Child {
 
         $this->SignalHandler->bind();
 
-        $this->QueueingEngine = new QueueingEngine($this->Config, $this->LogentryConfig);
+        $this->QueueingEngine = new QueueingEngine($this->Config, $this->LogentryConfig, $this->Syslog);
         $this->Queue = $this->QueueingEngine->getQueue();
         $this->Queue->connect();
     }

--- a/src/Childs/MiscChild.php
+++ b/src/Childs/MiscChild.php
@@ -121,7 +121,7 @@ class MiscChild extends Child {
         $this->SignalHandler->bind();
 
 
-        $this->QueueingEngine = new QueueingEngine($this->Config, $this->NotificationConfig);
+        $this->QueueingEngine = new QueueingEngine($this->Config, $this->NotificationConfig, $this->Syslog);
         $this->Queue = $this->QueueingEngine->getQueue();
         $this->Queue->addQueue($this->AcknowledgementConfig);
         $this->Queue->addQueue($this->DowntimeConfig);

--- a/src/Childs/PerfdataChild.php
+++ b/src/Childs/PerfdataChild.php
@@ -110,7 +110,7 @@ class PerfdataChild extends Child {
         $this->SignalHandler->bind();
 
 
-        $this->QueueingEngine = new QueueingEngine($this->Config, $this->PerfdataConfig);
+        $this->QueueingEngine = new QueueingEngine($this->Config, $this->PerfdataConfig, $this->Syslog);
         $this->Queue = $this->QueueingEngine->getQueue();
         $this->Queue->connect();
     }

--- a/src/Childs/ServicecheckChild.php
+++ b/src/Childs/ServicecheckChild.php
@@ -99,7 +99,7 @@ class ServicecheckChild extends Child {
 
         $this->SignalHandler->bind();
 
-        $this->QueueingEngine = new QueueingEngine($this->Config, $this->ServicecheckConfig);
+        $this->QueueingEngine = new QueueingEngine($this->Config, $this->ServicecheckConfig, $this->Syslog);
         $this->Queue = $this->QueueingEngine->getQueue();
         $this->Queue->connect();
     }

--- a/src/Childs/ServicestatusChild.php
+++ b/src/Childs/ServicestatusChild.php
@@ -127,7 +127,7 @@ class ServicestatusChild extends Child {
 
         $this->SignalHandler->bind();
 
-        $this->QueueingEngine = new QueueingEngine($this->Config, $this->ServicestatusConfig);
+        $this->QueueingEngine = new QueueingEngine($this->Config, $this->ServicestatusConfig, $this->Syslog);
         $this->Queue = $this->QueueingEngine->getQueue();
         $this->Queue->connect();
 

--- a/src/Childs/StatechangeChild.php
+++ b/src/Childs/StatechangeChild.php
@@ -95,7 +95,7 @@ class StatechangeChild extends Child {
 
         $this->SignalHandler->bind();
 
-        $this->QueueingEngine = new QueueingEngine($this->Config, $this->StatechangeConfig);
+        $this->QueueingEngine = new QueueingEngine($this->Config, $this->StatechangeConfig, $this->Syslog);
         $this->Queue = $this->QueueingEngine->getQueue();
         $this->Queue->connect();
     }

--- a/src/GearmanWorker.php
+++ b/src/GearmanWorker.php
@@ -49,13 +49,20 @@ class GearmanWorker implements QueueInterface {
     private $queues = [];
 
     /**
+     * @var Syslog
+     */
+    private $Syslog;
+
+    /**
      * GearmanWorker constructor.
      * @param WorkerConfig $WorkerConfig
      * @param Config $Config
+     * @param Syslog $Syslog
      */
-    public function __construct(WorkerConfig $WorkerConfig, Config $Config) {
+    public function __construct(WorkerConfig $WorkerConfig, Config $Config, Syslog $Syslog) {
         $this->WorkerConfig = $WorkerConfig;
         $this->Config = $Config;
+        $this->Syslog = $Syslog;
         $this->addQueue($this->WorkerConfig);
     }
 
@@ -93,12 +100,16 @@ class GearmanWorker implements QueueInterface {
     }
 
     /**
-     * @param $job
+     * @param \GearmanJob $job
      * @return void
      */
     public function handleJob($job) {
         $this->lastJobData = null;
-        $this->lastJobData = json_decode($job->workload());
+
+        $data = JSONUTF8::decodeJson($job->workload(), $this->Syslog);
+        if($data){
+            $this->lastJobData = $data;
+        }
     }
 
 }

--- a/src/JSONUTF8.php
+++ b/src/JSONUTF8.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Statusengine Worker
+ * Copyright (C) 2016-2019  Daniel Ziegler
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Statusengine;
+
+
+class JSONUTF8 {
+
+    /**
+     * @param string $json
+     * @param Syslog $Syslog
+     * @return bool|mixed
+     */
+    public static function decodeJson($json, Syslog $Syslog) {
+        $payload = json_decode($json);
+        $errno = json_last_error();
+        if ($errno === JSON_ERROR_UTF8) {
+            //Try to detect charset and retry to json_decode
+
+            $enclist = [
+                'UTF-8',
+                'ISO-8859-15',
+                'ISO-8859-1', 'ISO-8859-16',
+                'Windows-1251', 'Windows-1252', 'Windows-1254',
+                'ASCII'
+            ];
+
+            $detectEncoding = mb_detect_encoding($json, $enclist);
+
+            $json = iconv($detectEncoding . "//TRANSLIT//IGNORE", "UTF-8", $json);
+            $payload = json_decode($json);
+            $errno = json_last_error();
+        }
+        // parsing error
+        if ($errno != JSON_ERROR_NONE) {
+            $Syslog->warning('Error while parsing JSON - ' . self::getJsonLastErrorMsg($errno));
+            $Syslog->debug('Couldn\'t parse: ' . $json);
+            return false;
+            // parsed object is not an object
+        } else if (!is_object($payload)) {
+            $Syslog->warning('Error while parsing JSON string - Response isn\'t an object');
+            $Syslog->debug('Invalid JSON: ' . $json);
+            return false;
+        } else {
+            return $payload;
+        }
+    }
+
+    /**
+     * @param int $errno
+     * @return string
+     */
+    private static function getJsonLastErrorMsg($errno) {
+        if (function_exists('json_last_error_msg')) {
+            return json_last_error_msg();
+        }
+
+        $errors = [
+            JSON_ERROR_NONE           => 'No error',
+            JSON_ERROR_DEPTH          => 'Maximum stack depth exceeded',
+            JSON_ERROR_STATE_MISMATCH => 'State mismatch (invalid or malformed JSON)',
+            JSON_ERROR_CTRL_CHAR      => 'Control character error, possibly incorrectly encoded',
+            JSON_ERROR_SYNTAX         => 'Syntax error',
+            JSON_ERROR_UTF8           => 'Malformed UTF-8 characters, possibly incorrectly encoded'
+        ];
+
+        return (isset($errors[$errno]) ? $errors[$errno] : 'Unknown error');
+    }
+
+}

--- a/src/ParentProcess.php
+++ b/src/ParentProcess.php
@@ -114,7 +114,7 @@ class ParentProcess {
         $this->StorageBackend = $StorageBackend;
         $this->ChildFactory = $ChildFactory;
 
-        $this->QueueingEngine = new QueueingEngine($this->Config, $this->MonitoringRestartConfig);
+        $this->QueueingEngine = new QueueingEngine($this->Config, $this->MonitoringRestartConfig, $this->Syslog);
         $this->Queue = $this->QueueingEngine->getQueue();
         $this->Queue->connect();
 

--- a/src/QueueingEngines/QueueInterface.php
+++ b/src/QueueingEngines/QueueInterface.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * Statusengine UI
- * Copyright (C) 2018  Daniel Ziegler
+ * Statusengine Worker
+ * Copyright (C) 2016-2019  Daniel Ziegler
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -20,6 +21,7 @@ namespace Statusengine\QueueingEngines;
 
 
 use Statusengine\Config;
+use Statusengine\Syslog;
 
 interface QueueInterface {
 
@@ -28,7 +30,7 @@ interface QueueInterface {
      * @param Config\WorkerConfig $WorkerConfig
      * @param Config $Config
      */
-    public function __construct(Config\WorkerConfig $WorkerConfig, Config $Config);
+    public function __construct(Config\WorkerConfig $WorkerConfig, Config $Config, Syslog $Syslog);
 
     /**
      * @return void

--- a/src/QueueingEngines/QueueingEngine.php
+++ b/src/QueueingEngines/QueueingEngine.php
@@ -22,6 +22,7 @@ namespace Statusengine\QueueingEngines;
 use Statusengine\Config;
 use Statusengine\GearmanWorker;
 use Statusengine\RabbitMqWorker;
+use Statusengine\Syslog;
 
 class QueueingEngine {
 
@@ -35,9 +36,15 @@ class QueueingEngine {
      */
     private $WorkerConfig;
 
-    public function __construct(Config $Config, Config\WorkerConfig $WorkerConfig) {
+    /**
+     * @var Syslog
+     */
+    private $Syslog;
+
+    public function __construct(Config $Config, Config\WorkerConfig $WorkerConfig, Syslog $Syslog) {
         $this->Config = $Config;
         $this->WorkerConfig = $WorkerConfig;
+        $this->Syslog = $Syslog;
     }
 
     /**
@@ -45,11 +52,11 @@ class QueueingEngine {
      */
     public function getQueue(){
         if($this->Config->isGearmanEnabled()){
-            return new GearmanWorker($this->WorkerConfig, $this->Config);
+            return new GearmanWorker($this->WorkerConfig, $this->Config, $this->Syslog);
         }
 
         if($this->Config->isRabbitMqEnabled()){
-            return new RabbitMqWorker($this->WorkerConfig, $this->Config);
+            return new RabbitMqWorker($this->WorkerConfig, $this->Config, $this->Syslog);
         }
     }
 


### PR DESCRIPTION
This feature is ported from Statusengine 2.x

Non UTF8 chars in plugin output will lead to missing data in the database:
![Bildschirmfoto vom 2019-10-04 15-30-08](https://user-images.githubusercontent.com/9019992/66213580-5a069180-e6c0-11e9-8764-f0acc973e627.png)
![no_output](https://user-images.githubusercontent.com/9019992/66213590-5e32af00-e6c0-11e9-87d4-a19c407abc4c.png)

This PR fixes this:
![convert_to_utf8](https://user-images.githubusercontent.com/9019992/66213607-668aea00-e6c0-11e9-8177-d1f253f6abc1.png)





