### PR TITLE
Add primary keys to mysql schema and use DBAL to manage the schema

### DIFF
--- a/bin/Console.php
+++ b/bin/Console.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Application;
 use Statusengine\Console\Statistics;
 use Statusengine\Console\Cleanup;
 use Statusengine\Console\Cluster;
+use Statusengine\Console\Database;
 
 $Config = new \Statusengine\Config();
 if($Config->getDisableHttpProxy()){
@@ -36,6 +37,7 @@ $application = new Application();
 $application->add(new Statistics());
 $application->add(new Cleanup());
 $application->add(new Cluster());
+$application->add(new Database());
 $application->run();
 
 

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,13 @@
     "ext-gearman": "*",
     "ext-mbstring": "*",
     "ext-bcmath": "*",
-    "symfony/yaml": "2.8",
-    "symfony/console": "2.8",
-    "crate/crate-dbal":"*",
-    "crate/crate-pdo":"~0.6.0",
-    "php-amqplib/php-amqplib": "^2.7"
+    "symfony/yaml": "^3.4",
+    "symfony/console": "^3.4",
+    "php-amqplib/php-amqplib": "^2.7",
+    "crate/crate-dbal": "^2.0",
+    "crate/crate-pdo": "^1.0",
+    "doctrine/dbal": "^2.9",
+    "doctrine/migrations": "^2.1"
   },
 
   "autoload": {

--- a/lib/mysql.php
+++ b/lib/mysql.php
@@ -593,14 +593,14 @@ $table->addColumn("long_output", "string", array (
   'default' => NULL,
   'length' => 8192,
 ));
+$table->setPrimaryKey([
+    "hostname",
+    "start_time"
+]);
 $table->addIndex([
-    "start_time", 
+    "start_time",
     "end_time"
 ], "times");
-$table->addIndex([
-    "hostname", 
-    "start_time"
-], "hostname");
 
 
 
@@ -1012,9 +1012,9 @@ $table->addColumn("unit", "string", array (
   'length' => 10,
 ));
 $table->addIndex([
-    "hostname", 
-    "service_description", 
-    "label", 
+    "hostname",
+    "service_description",
+    "label",
     "timestamp_unix"
 ], "metric");
 $table->addIndex([
@@ -1320,7 +1320,7 @@ $table->addColumn("ack_data", "string", array (
   'length' => 1024,
 ));
 $table->addIndex([
-    "hostname", 
+    "hostname",
     "service_description"
 ], "servicename");
 $table->addIndex([
@@ -1518,16 +1518,11 @@ $table->addColumn("long_output", "string", array (
   'default' => NULL,
   'length' => 8192,
 ));
-$table->addIndex([
-    "service_description", 
+$table->setPrimaryKey([
+    "hostname",
+    "service_description",
     "state_time"
-], "servicename_time");
-$table->addIndex([
-    "hostname", 
-    "service_description", 
-    "state_time"
-], "host_servicename_time");
-
+]);
 
 
 /****************************************
@@ -1639,11 +1634,11 @@ $table->addColumn("long_output", "string", array (
   'default' => NULL,
   'length' => 8192,
 ));
-$table->addIndex([
+$table->setPrimaryKey([
     "hostname", 
     "service_description", 
     "start_time"
-], "servicename");
+]);
 
 
 

--- a/lib/mysql.php
+++ b/lib/mysql.php
@@ -6,8 +6,6 @@ use Doctrine\DBAL\Schema\Schema;
 require_once __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 $schema = new Schema();
 
-$tables = [];
-
 /****************************************
  * Define: statusengine_dbversion
  ***************************************/
@@ -31,9 +29,6 @@ $table->addColumn("dbversion", "string", array (
 $table->setPrimaryKey([
     "id"
 ]);
-
-//Add table to collection
-$tables[] = $table;
 
 
 
@@ -107,9 +102,6 @@ $table->addIndex([
 $table->addIndex([
     "hostname"
 ], "hostname");
-
-//Add table to collection
-$tables[] = $table;
 
 
 
@@ -227,9 +219,6 @@ $table->addIndex([
     "was_cancelled"
 ], "list");
 
-//Add table to collection
-$tables[] = $table;
-
 
 
 /****************************************
@@ -318,9 +307,6 @@ $table->addIndex([
 $table->addIndex([
     "hostname"
 ], "hostname");
-
-//Add table to collection
-$tables[] = $table;
 
 
 
@@ -420,9 +406,6 @@ $table->setPrimaryKey([
     "internal_downtime_id"
 ]);
 
-//Add table to collection
-$tables[] = $table;
-
 
 
 /****************************************
@@ -505,9 +488,6 @@ $table->setPrimaryKey([
     "hostname", 
     "state_time"
 ]);
-
-//Add table to collection
-$tables[] = $table;
 
 
 
@@ -621,9 +601,6 @@ $table->addIndex([
     "hostname", 
     "start_time"
 ], "hostname");
-
-//Add table to collection
-$tables[] = $table;
 
 
 
@@ -892,9 +869,6 @@ $table->setPrimaryKey([
     "hostname"
 ]);
 
-//Add table to collection
-$tables[] = $table;
-
 
 
 /****************************************
@@ -949,9 +923,6 @@ $table->addIndex([
     "entry_time"
 ], "logentry_data_time");
 
-//Add table to collection
-$tables[] = $table;
-
 
 
 /****************************************
@@ -984,9 +955,6 @@ $table->addColumn("node_start_time", "bigint", array (
 $table->setPrimaryKey([
     "node_name"
 ]);
-
-//Add table to collection
-$tables[] = $table;
 
 
 
@@ -1052,9 +1020,6 @@ $table->addIndex([
 $table->addIndex([
     "timestamp_unix"
 ], "timestamp_unix");
-
-//Add table to collection
-$tables[] = $table;
 
 
 
@@ -1140,9 +1105,6 @@ $table->addIndex([
 $table->addIndex([
     "entry_time"
 ], "entry_time");
-
-//Add table to collection
-$tables[] = $table;
 
 
 
@@ -1268,9 +1230,6 @@ $table->addIndex([
     "was_cancelled"
 ], "report");
 
-//Add table to collection
-$tables[] = $table;
-
 
 
 /****************************************
@@ -1367,9 +1326,6 @@ $table->addIndex([
 $table->addIndex([
     "start_time"
 ], "start_time");
-
-//Add table to collection
-$tables[] = $table;
 
 
 
@@ -1477,9 +1433,6 @@ $table->setPrimaryKey([
     "internal_downtime_id"
 ]);
 
-//Add table to collection
-$tables[] = $table;
-
 
 
 /****************************************
@@ -1574,9 +1527,6 @@ $table->addIndex([
     "service_description", 
     "state_time"
 ], "host_servicename_time");
-
-//Add table to collection
-$tables[] = $table;
 
 
 
@@ -1694,9 +1644,6 @@ $table->addIndex([
     "service_description", 
     "start_time"
 ], "servicename");
-
-//Add table to collection
-$tables[] = $table;
 
 
 
@@ -1991,9 +1938,6 @@ $table->addIndex([
     "current_state"
 ], "issues");
 
-//Add table to collection
-$tables[] = $table;
-
 
 
 /****************************************
@@ -2044,9 +1988,6 @@ $table->addIndex([
     "node_name"
 ], "node_name");
 
-//Add table to collection
-$tables[] = $table;
-
 
 
 /****************************************
@@ -2074,9 +2015,6 @@ $table->addIndex([
     "username", 
     "password"
 ], "username");
-
-//Add table to collection
-$tables[] = $table;
 
 
 

--- a/lib/mysql.php
+++ b/lib/mysql.php
@@ -1,0 +1,2083 @@
+<?php
+
+use Doctrine\DBAL\Schema\Schema;
+
+
+require_once __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+$schema = new Schema();
+
+$tables = [];
+
+/****************************************
+ * Define: statusengine_dbversion
+ ***************************************/
+$table = $schema->createTable("statusengine_dbversion");
+$table->addOption("engine" , "InnoDB");
+$table->addOption("collation" , "utf8mb4_general_ci");
+$table->addOption("comment" , "");
+$table->addColumn("id", "integer", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("dbversion", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '3.0.0',
+  'length' => 255,
+));
+$table->setPrimaryKey([
+    "id"
+]);
+
+//Add table to collection
+$tables[] = $table;
+
+
+
+/****************************************
+ * Define: statusengine_host_acknowledgements
+ ***************************************/
+$table = $schema->createTable("statusengine_host_acknowledgements");
+$table->addOption("engine" , "InnoDB");
+$table->addOption("collation" , "utf8mb4_general_ci");
+$table->addOption("comment" , "");
+$table->addColumn("hostname", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("state", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("author_name", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("comment_data", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("entry_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("acknowledgement_type", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("is_sticky", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("persistent_comment", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("notify_contacts", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addIndex([
+    "entry_time"
+], "entry_time");
+$table->addIndex([
+    "hostname"
+], "hostname");
+
+//Add table to collection
+$tables[] = $table;
+
+
+
+/****************************************
+ * Define: statusengine_host_downtimehistory
+ ***************************************/
+$table = $schema->createTable("statusengine_host_downtimehistory");
+$table->addOption("engine" , "InnoDB");
+$table->addOption("collation" , "utf8mb4_general_ci");
+$table->addOption("comment" , "");
+$table->addColumn("hostname", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("internal_downtime_id", "integer", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("scheduled_start_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("node_name", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("entry_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("author_name", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("comment_data", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("triggered_by_id", "integer", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+));
+$table->addColumn("is_fixed", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("duration", "integer", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+));
+$table->addColumn("scheduled_end_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("was_started", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("actual_start_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("actual_end_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("was_cancelled", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->setPrimaryKey([
+    "hostname", 
+    "node_name", 
+    "scheduled_start_time", 
+    "internal_downtime_id"
+]);
+$table->addIndex([
+    "hostname", 
+    "scheduled_start_time", 
+    "scheduled_end_time", 
+    "was_cancelled"
+], "list");
+
+//Add table to collection
+$tables[] = $table;
+
+
+
+/****************************************
+ * Define: statusengine_host_notifications
+ ***************************************/
+$table = $schema->createTable("statusengine_host_notifications");
+$table->addOption("engine" , "InnoDB");
+$table->addOption("collation" , "utf8mb4_general_ci");
+$table->addOption("comment" , "");
+$table->addColumn("hostname", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("contact_name", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("command_name", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("command_args", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("state", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("start_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("end_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("reason_type", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("output", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("ack_author", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("ack_data", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addIndex([
+    "start_time"
+], "start_time");
+$table->addIndex([
+    "hostname"
+], "hostname");
+
+//Add table to collection
+$tables[] = $table;
+
+
+
+/****************************************
+ * Define: statusengine_host_scheduleddowntimes
+ ***************************************/
+$table = $schema->createTable("statusengine_host_scheduleddowntimes");
+$table->addOption("engine" , "InnoDB");
+$table->addOption("collation" , "utf8mb4_general_ci");
+$table->addOption("comment" , "");
+$table->addColumn("hostname", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("internal_downtime_id", "integer", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("scheduled_start_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("node_name", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("entry_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("author_name", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("comment_data", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("triggered_by_id", "integer", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+));
+$table->addColumn("is_fixed", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("duration", "integer", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+));
+$table->addColumn("scheduled_end_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("was_started", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("actual_start_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->setPrimaryKey([
+    "hostname", 
+    "node_name", 
+    "scheduled_start_time", 
+    "internal_downtime_id"
+]);
+
+//Add table to collection
+$tables[] = $table;
+
+
+
+/****************************************
+ * Define: statusengine_host_statehistory
+ ***************************************/
+$table = $schema->createTable("statusengine_host_statehistory");
+$table->addOption("engine" , "InnoDB");
+$table->addOption("collation" , "utf8mb4_general_ci");
+$table->addOption("comment" , "");
+$table->addColumn("hostname", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("state_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("state_change", "boolean", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("state", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("is_hardstate", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("current_check_attempt", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("max_check_attempts", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("last_state", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("last_hard_state", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("output", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("long_output", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 8192,
+));
+$table->setPrimaryKey([
+    "hostname", 
+    "state_time"
+]);
+
+//Add table to collection
+$tables[] = $table;
+
+
+
+/****************************************
+ * Define: statusengine_hostchecks
+ ***************************************/
+$table = $schema->createTable("statusengine_hostchecks");
+$table->addOption("engine" , "InnoDB");
+$table->addOption("collation" , "utf8mb4_general_ci");
+$table->addOption("comment" , "");
+$table->addColumn("hostname", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("state", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("is_hardstate", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("start_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("end_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("output", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("timeout", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("early_timeout", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("latency", "float", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("execution_time", "float", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("perfdata", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("command", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("current_check_attempt", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("max_check_attempts", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("long_output", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 8192,
+));
+$table->addIndex([
+    "start_time", 
+    "end_time"
+], "times");
+$table->addIndex([
+    "hostname", 
+    "start_time"
+], "hostname");
+
+//Add table to collection
+$tables[] = $table;
+
+
+
+/****************************************
+ * Define: statusengine_hoststatus
+ ***************************************/
+$table = $schema->createTable("statusengine_hoststatus");
+$table->addOption("engine" , "InnoDB");
+$table->addOption("collation" , "utf8mb4_general_ci");
+$table->addOption("comment" , "");
+$table->addColumn("hostname", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("status_update_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("output", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("long_output", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("perfdata", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("current_state", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("current_check_attempt", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("max_check_attempts", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("last_check", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("next_check", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("is_passive_check", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("last_state_change", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("last_hard_state_change", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("last_hard_state", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("is_hardstate", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("last_notification", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("next_notification", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("notifications_enabled", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("problem_has_been_acknowledged", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("acknowledgement_type", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("passive_checks_enabled", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("active_checks_enabled", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("event_handler_enabled", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("flap_detection_enabled", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("is_flapping", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("latency", "float", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("execution_time", "float", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("scheduled_downtime_depth", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("process_performance_data", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("obsess_over_host", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("normal_check_interval", "integer", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("retry_check_interval", "integer", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("check_timeperiod", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("node_name", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("last_time_up", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("last_time_down", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("last_time_unreachable", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("current_notification_number", "integer", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("percent_state_change", "float", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("event_handler", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("check_command", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->setPrimaryKey([
+    "hostname"
+]);
+
+//Add table to collection
+$tables[] = $table;
+
+
+
+/****************************************
+ * Define: statusengine_logentries
+ ***************************************/
+$table = $schema->createTable("statusengine_logentries");
+$table->addOption("engine" , "InnoDB");
+$table->addOption("collation" , "utf8mb4_general_ci");
+$table->addOption("comment" , "");
+$table->addColumn("id", "bigint", array (
+  'unsigned' => true,
+  'autoincrement' => true,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("entry_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("logentry_type", "integer", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("logentry_data", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("node_name", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->setPrimaryKey([
+    "id"
+]);
+$table->addIndex([
+    "entry_time", 
+    "logentry_data", 
+    "node_name"
+], "logentries");
+$table->addIndex([
+    "logentry_data", 
+    "entry_time"
+], "logentry_data_time");
+
+//Add table to collection
+$tables[] = $table;
+
+
+
+/****************************************
+ * Define: statusengine_nodes
+ ***************************************/
+$table = $schema->createTable("statusengine_nodes");
+$table->addOption("engine" , "InnoDB");
+$table->addOption("collation" , "utf8mb4_general_ci");
+$table->addOption("comment" , "");
+$table->addColumn("node_name", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("node_version", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("node_start_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->setPrimaryKey([
+    "node_name"
+]);
+
+//Add table to collection
+$tables[] = $table;
+
+
+
+/****************************************
+ * Define: statusengine_perfdata
+ ***************************************/
+$table = $schema->createTable("statusengine_perfdata");
+$table->addOption("engine" , "InnoDB");
+$table->addOption("collation" , "utf8mb4_general_ci");
+$table->addOption("comment" , "");
+$table->addColumn("hostname", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("service_description", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("label", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("timestamp", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("timestamp_unix", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("value", "float", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+));
+$table->addColumn("unit", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 10,
+));
+$table->addIndex([
+    "hostname", 
+    "service_description", 
+    "label", 
+    "timestamp_unix"
+], "metric");
+$table->addIndex([
+    "timestamp_unix"
+], "timestamp_unix");
+
+//Add table to collection
+$tables[] = $table;
+
+
+
+/****************************************
+ * Define: statusengine_service_acknowledgements
+ ***************************************/
+$table = $schema->createTable("statusengine_service_acknowledgements");
+$table->addOption("engine" , "InnoDB");
+$table->addOption("collation" , "utf8mb4_general_ci");
+$table->addOption("comment" , "");
+$table->addColumn("hostname", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("service_description", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("state", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("author_name", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("comment_data", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("entry_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("acknowledgement_type", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("is_sticky", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("persistent_comment", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("notify_contacts", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addIndex([
+    "service_description", 
+    "entry_time"
+], "servicedesc_time");
+$table->addIndex([
+    "hostname", 
+    "service_description"
+], "servicename");
+$table->addIndex([
+    "entry_time"
+], "entry_time");
+
+//Add table to collection
+$tables[] = $table;
+
+
+
+/****************************************
+ * Define: statusengine_service_downtimehistory
+ ***************************************/
+$table = $schema->createTable("statusengine_service_downtimehistory");
+$table->addOption("engine" , "InnoDB");
+$table->addOption("collation" , "utf8mb4_general_ci");
+$table->addOption("comment" , "");
+$table->addColumn("hostname", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("service_description", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("internal_downtime_id", "integer", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("scheduled_start_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("node_name", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("entry_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("author_name", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("comment_data", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("triggered_by_id", "integer", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+));
+$table->addColumn("is_fixed", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("duration", "integer", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+));
+$table->addColumn("scheduled_end_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("was_started", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("actual_start_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("actual_end_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("was_cancelled", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->setPrimaryKey([
+    "hostname", 
+    "service_description", 
+    "node_name", 
+    "scheduled_start_time", 
+    "internal_downtime_id"
+]);
+$table->addIndex([
+    "service_description", 
+    "scheduled_start_time", 
+    "scheduled_end_time", 
+    "was_cancelled"
+], "report");
+
+//Add table to collection
+$tables[] = $table;
+
+
+
+/****************************************
+ * Define: statusengine_service_notifications
+ ***************************************/
+$table = $schema->createTable("statusengine_service_notifications");
+$table->addOption("engine" , "InnoDB");
+$table->addOption("collation" , "utf8mb4_general_ci");
+$table->addOption("comment" , "");
+$table->addColumn("hostname", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("service_description", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("contact_name", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("command_name", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("command_args", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("state", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("start_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("end_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("reason_type", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("output", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("ack_author", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("ack_data", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addIndex([
+    "hostname", 
+    "service_description"
+], "servicename");
+$table->addIndex([
+    "start_time"
+], "start_time");
+
+//Add table to collection
+$tables[] = $table;
+
+
+
+/****************************************
+ * Define: statusengine_service_scheduleddowntimes
+ ***************************************/
+$table = $schema->createTable("statusengine_service_scheduleddowntimes");
+$table->addOption("engine" , "InnoDB");
+$table->addOption("collation" , "utf8mb4_general_ci");
+$table->addOption("comment" , "");
+$table->addColumn("hostname", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("service_description", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("internal_downtime_id", "integer", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("scheduled_start_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("node_name", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("entry_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("author_name", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("comment_data", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("triggered_by_id", "integer", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+));
+$table->addColumn("is_fixed", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("duration", "integer", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+));
+$table->addColumn("scheduled_end_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("was_started", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("actual_start_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->setPrimaryKey([
+    "hostname", 
+    "service_description", 
+    "node_name", 
+    "scheduled_start_time", 
+    "internal_downtime_id"
+]);
+
+//Add table to collection
+$tables[] = $table;
+
+
+
+/****************************************
+ * Define: statusengine_service_statehistory
+ ***************************************/
+$table = $schema->createTable("statusengine_service_statehistory");
+$table->addOption("engine" , "InnoDB");
+$table->addOption("collation" , "utf8mb4_general_ci");
+$table->addOption("comment" , "");
+$table->addColumn("hostname", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("service_description", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("state_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("state_change", "boolean", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("state", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("is_hardstate", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("current_check_attempt", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("max_check_attempts", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("last_state", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("last_hard_state", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("output", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("long_output", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 8192,
+));
+$table->addIndex([
+    "service_description", 
+    "state_time"
+], "servicename_time");
+$table->addIndex([
+    "hostname", 
+    "service_description", 
+    "state_time"
+], "host_servicename_time");
+
+//Add table to collection
+$tables[] = $table;
+
+
+
+/****************************************
+ * Define: statusengine_servicechecks
+ ***************************************/
+$table = $schema->createTable("statusengine_servicechecks");
+$table->addOption("engine" , "InnoDB");
+$table->addOption("collation" , "utf8mb4_general_ci");
+$table->addOption("comment" , "");
+$table->addColumn("hostname", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("service_description", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("state", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("is_hardstate", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("start_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("end_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("output", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("timeout", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("early_timeout", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("latency", "float", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("execution_time", "float", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("perfdata", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("command", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("current_check_attempt", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("max_check_attempts", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("long_output", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 8192,
+));
+$table->addIndex([
+    "hostname", 
+    "service_description", 
+    "start_time"
+], "servicename");
+
+//Add table to collection
+$tables[] = $table;
+
+
+
+/****************************************
+ * Define: statusengine_servicestatus
+ ***************************************/
+$table = $schema->createTable("statusengine_servicestatus");
+$table->addOption("engine" , "InnoDB");
+$table->addOption("collation" , "utf8mb4_general_ci");
+$table->addOption("comment" , "");
+$table->addColumn("hostname", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("service_description", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("status_update_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("output", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("long_output", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("perfdata", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 1024,
+));
+$table->addColumn("current_state", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("current_check_attempt", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("max_check_attempts", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("last_check", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("next_check", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("is_passive_check", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("last_state_change", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("last_hard_state_change", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("last_hard_state", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("is_hardstate", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("last_notification", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("next_notification", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("notifications_enabled", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("problem_has_been_acknowledged", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("acknowledgement_type", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("passive_checks_enabled", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("active_checks_enabled", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("event_handler_enabled", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("flap_detection_enabled", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("is_flapping", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("latency", "float", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("execution_time", "float", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("scheduled_downtime_depth", "smallint", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("process_performance_data", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("obsess_over_service", "boolean", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("normal_check_interval", "integer", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("retry_check_interval", "integer", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("check_timeperiod", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("node_name", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("last_time_ok", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("last_time_warning", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("last_time_critical", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("last_time_unknown", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("current_notification_number", "integer", array (
+  'unsigned' => true,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("percent_state_change", "float", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => '0',
+));
+$table->addColumn("event_handler", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("check_command", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->setPrimaryKey([
+    "hostname", 
+    "service_description"
+]);
+$table->addIndex([
+    "service_description"
+], "service_description");
+$table->addIndex([
+    "current_state", 
+    "node_name"
+], "current_state_node");
+$table->addIndex([
+    "problem_has_been_acknowledged", 
+    "scheduled_downtime_depth", 
+    "current_state"
+], "issues");
+
+//Add table to collection
+$tables[] = $table;
+
+
+
+/****************************************
+ * Define: statusengine_tasks
+ ***************************************/
+$table = $schema->createTable("statusengine_tasks");
+$table->addOption("engine" , "InnoDB");
+$table->addOption("collation" , "utf8mb4_general_ci");
+$table->addOption("comment" , "");
+$table->addColumn("uuid", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("node_name", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("entry_time", "bigint", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => true,
+  'default' => NULL,
+));
+$table->addColumn("type", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("payload", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 8192,
+));
+$table->addIndex([
+    "uuid"
+], "uuid");
+$table->addIndex([
+    "node_name"
+], "node_name");
+
+//Add table to collection
+$tables[] = $table;
+
+
+
+/****************************************
+ * Define: statusengine_users
+ ***************************************/
+$table = $schema->createTable("statusengine_users");
+$table->addOption("engine" , "InnoDB");
+$table->addOption("collation" , "utf8mb4_general_ci");
+$table->addOption("comment" , "");
+$table->addColumn("username", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addColumn("password", "string", array (
+  'unsigned' => false,
+  'autoincrement' => false,
+  'notnull' => false,
+  'default' => NULL,
+  'length' => 255,
+));
+$table->addIndex([
+    "username", 
+    "password"
+], "username");
+
+//Add table to collection
+$tables[] = $table;
+
+
+
+return $schema;

--- a/lib/mysql.php
+++ b/lib/mysql.php
@@ -15,7 +15,7 @@ $table->addOption("collation" , "utf8mb4_general_ci");
 $table->addOption("comment" , "");
 $table->addColumn("id", "integer", array (
   'unsigned' => false,
-  'autoincrement' => false,
+  'autoincrement' => true,
   'notnull' => true,
   'default' => NULL,
 ));

--- a/lib/mysql.sql
+++ b/lib/mysql.sql
@@ -1,424 +1,447 @@
 -- THIS IS NOT A CrateDB.sql FILE
 -- THIS FILE WAS CREATED FOR MySQL
 
-CREATE TABLE IF NOT EXISTS `statusengine_logentries` (
-  `entry_time`    BIGINT(13) NOT NULL,
-  `logentry_type` INT(11)      DEFAULT '0',
-  `logentry_data` VARCHAR(255) DEFAULT NULL,
-  `node_name`     VARCHAR(255) DEFAULT NULL,
-  KEY `logentries` (`entry_time`, `logentry_data`, `node_name`),
-  KEY `logentry_data_time` (`logentry_data`, `entry_time`)
+CREATE TABLE IF NOT EXISTS `statusengine_logentries`
+(
+    `id`            bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+    `entry_time`    BIGINT(13)          NOT NULL,
+    `logentry_type` INT(11)      DEFAULT '0',
+    `logentry_data` VARCHAR(255) DEFAULT NULL,
+    `node_name`     VARCHAR(255) DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    KEY `logentries` (`entry_time`, `logentry_data`, `node_name`),
+    KEY `logentry_data_time` (`logentry_data`, `entry_time`)
 )
-  ENGINE = InnoDB
-  DEFAULT CHARSET = utf8;
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4;
 
-CREATE TABLE `statusengine_host_statehistory` (
-  `hostname`              VARCHAR(255),
-  `state_time`            BIGINT(13) NOT NULL,
-  `state_change`          TINYINT(1)          DEFAULT 0,
-  `state`                 TINYINT(2) UNSIGNED DEFAULT 0,
-  `is_hardstate`          TINYINT(1) UNSIGNED DEFAULT 0,
-  `current_check_attempt` TINYINT(3) UNSIGNED DEFAULT 0,
-  `max_check_attempts`    TINYINT(3) UNSIGNED DEFAULT 0,
-  `last_state`            TINYINT(2) UNSIGNED DEFAULT 0,
-  `last_hard_state`       TINYINT(2) UNSIGNED DEFAULT 0,
-  `output`                VARCHAR(1024),
-  `long_output`           VARCHAR(8192),
-  KEY `hostname_time` (`hostname`, `state_time`)
+CREATE TABLE `statusengine_host_statehistory`
+(
+    `hostname`              VARCHAR(255),
+    `state_time`            BIGINT(13) NOT NULL,
+    `state_change`          TINYINT(1)           DEFAULT 0,
+    `state`                 SMALLINT(2) UNSIGNED DEFAULT 0,
+    `is_hardstate`          TINYINT(1) UNSIGNED  DEFAULT 0,
+    `current_check_attempt` SMALLINT(3) UNSIGNED DEFAULT 0,
+    `max_check_attempts`    SMALLINT(3) UNSIGNED DEFAULT 0,
+    `last_state`            SMALLINT(2) UNSIGNED DEFAULT 0,
+    `last_hard_state`       SMALLINT(2) UNSIGNED DEFAULT 0,
+    `output`                VARCHAR(1024),
+    `long_output`           VARCHAR(8192),
+    PRIMARY KEY (`hostname`, `state_time`)
 )
-  ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_general_ci;
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_general_ci;
 
-CREATE TABLE `statusengine_service_statehistory` (
-  `hostname`              VARCHAR(255),
-  `service_description`   VARCHAR(255),
-  `state_time`            BIGINT(13) NOT NULL,
-  `state_change`          TINYINT(1)          DEFAULT 0,
-  `state`                 TINYINT(2) UNSIGNED DEFAULT 0,
-  `is_hardstate`          TINYINT(1) UNSIGNED DEFAULT 0,
-  `current_check_attempt` TINYINT(3) UNSIGNED DEFAULT 0,
-  `max_check_attempts`    TINYINT(3) UNSIGNED DEFAULT 0,
-  `last_state`            TINYINT(2) UNSIGNED DEFAULT 0,
-  `last_hard_state`       TINYINT(2) UNSIGNED DEFAULT 0,
-  `output`                VARCHAR(1024),
-  `long_output`           VARCHAR(8192),
-  KEY `host_servicename_time` (`hostname`, `service_description`, `state_time`),
-  KEY `servicename_time` (`service_description`, `state_time`)
-
-)
-  ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_general_ci;
-
-
-CREATE TABLE `statusengine_hostchecks` (
-  `hostname`              VARCHAR(255),
-  `state`                 TINYINT(2) UNSIGNED DEFAULT 0,
-  `is_hardstate`          TINYINT(1) UNSIGNED DEFAULT 0,
-  `start_time`            BIGINT(13) NOT NULL,
-  `end_time`              BIGINT(13) NOT NULL,
-  `output`                VARCHAR(1024),
-  `timeout`               TINYINT(3) UNSIGNED DEFAULT 0,
-  `early_timeout`         TINYINT(1) UNSIGNED DEFAULT 0,
-  `latency`               FLOAT               DEFAULT 0,
-  `execution_time`        FLOAT               DEFAULT 0,
-  `perfdata`              VARCHAR(1024),
-  `command`               VARCHAR(1024),
-  `current_check_attempt` TINYINT(3) UNSIGNED DEFAULT 0,
-  `max_check_attempts`    TINYINT(3) UNSIGNED DEFAULT 0,
-  `long_output`           VARCHAR(8192),
-  KEY `times` (`start_time`, `end_time`),
-  KEY `hostname` (`hostname`, `start_time`)
-)
-  ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_general_ci;
-
-CREATE TABLE `statusengine_servicechecks` (
-  `hostname`              VARCHAR(255),
-  `service_description`   VARCHAR(255),
-  `state`                 TINYINT(2) UNSIGNED DEFAULT 0,
-  `is_hardstate`          TINYINT(1) UNSIGNED DEFAULT 0,
-  `start_time`            BIGINT(13) NOT NULL,
-  `end_time`              BIGINT(13) NOT NULL,
-  `output`                VARCHAR(1024),
-  `timeout`               TINYINT(3) UNSIGNED DEFAULT 0,
-  `early_timeout`         TINYINT(1) UNSIGNED DEFAULT 0,
-  `latency`               FLOAT               DEFAULT 0,
-  `execution_time`        FLOAT               DEFAULT 0,
-  `perfdata`              VARCHAR(1024),
-  `command`               VARCHAR(1024),
-  `current_check_attempt` TINYINT(3) UNSIGNED DEFAULT 0,
-  `max_check_attempts`    TINYINT(3) UNSIGNED DEFAULT 0,
-  `long_output`           VARCHAR(8192),
-  KEY `servicename` (`hostname`, `service_description`, `start_time`)
+CREATE TABLE `statusengine_service_statehistory`
+(
+    `hostname`              VARCHAR(255),
+    `service_description`   VARCHAR(255),
+    `state_time`            BIGINT(13) NOT NULL,
+    `state_change`          TINYINT(1)           DEFAULT 0,
+    `state`                 SMALLINT(2) UNSIGNED DEFAULT 0,
+    `is_hardstate`          TINYINT(1) UNSIGNED  DEFAULT 0,
+    `current_check_attempt` SMALLINT(3) UNSIGNED DEFAULT 0,
+    `max_check_attempts`    SMALLINT(3) UNSIGNED DEFAULT 0,
+    `last_state`            SMALLINT(2) UNSIGNED DEFAULT 0,
+    `last_hard_state`       SMALLINT(2) UNSIGNED DEFAULT 0,
+    `output`                VARCHAR(1024),
+    `long_output`           VARCHAR(8192),
+    KEY `host_servicename_time` (`hostname`, `service_description`, `state_time`),
+    KEY `servicename_time` (`service_description`, `state_time`)
 
 )
-  ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_general_ci;
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_general_ci;
 
-CREATE TABLE `statusengine_hoststatus` (
-  `hostname`                      VARCHAR(255),
-  `status_update_time`            BIGINT(13) NOT NULL,
-  `output`                        VARCHAR(1024),
-  `long_output`                   VARCHAR(1024),
-  `perfdata`                      VARCHAR(1024),
-  `current_state`                 TINYINT(2) UNSIGNED DEFAULT 0,
-  `current_check_attempt`         TINYINT(3) UNSIGNED DEFAULT 0,
-  `max_check_attempts`            TINYINT(3) UNSIGNED DEFAULT 0,
-  `last_check`                    BIGINT(13) NOT NULL,
-  `next_check`                    BIGINT(13) NOT NULL,
-  `is_passive_check`              TINYINT(1) UNSIGNED DEFAULT 0,
-  `last_state_change`             BIGINT(13) NOT NULL,
-  `last_hard_state_change`        BIGINT(13) NOT NULL,
-  `last_hard_state`               TINYINT(2) UNSIGNED DEFAULT 0,
-  `is_hardstate`                  TINYINT(1) UNSIGNED DEFAULT 0,
-  `last_notification`             BIGINT(13) NOT NULL,
-  `next_notification`             BIGINT(13) NOT NULL,
-  `notifications_enabled`         TINYINT(1) UNSIGNED DEFAULT 0,
-  `problem_has_been_acknowledged` TINYINT(1) UNSIGNED DEFAULT 0,
-  `acknowledgement_type`          TINYINT(2) UNSIGNED DEFAULT 0,
-  `passive_checks_enabled`        TINYINT(1) UNSIGNED DEFAULT 0,
-  `active_checks_enabled`         TINYINT(1) UNSIGNED DEFAULT 0,
-  `event_handler_enabled`         TINYINT(1) UNSIGNED DEFAULT 0,
-  `flap_detection_enabled`        TINYINT(1) UNSIGNED DEFAULT 0,
-  `is_flapping`                   TINYINT(1) UNSIGNED DEFAULT 0,
-  `latency`                       FLOAT               DEFAULT 0,
-  `execution_time`                FLOAT               DEFAULT 0,
-  `scheduled_downtime_depth`      TINYINT(2) UNSIGNED DEFAULT 0,
-  `process_performance_data`      TINYINT(1) UNSIGNED DEFAULT 0,
-  `obsess_over_host`              TINYINT(1) UNSIGNED DEFAULT 0,
-  `normal_check_interval`         INT(11) UNSIGNED    DEFAULT 0,
-  `retry_check_interval`          INT(11) UNSIGNED    DEFAULT 0,
-  `check_timeperiod`              VARCHAR(255),
-  `node_name`                     VARCHAR(255),
-  `last_time_up`                  BIGINT(13) NOT NULL,
-  `last_time_down`                BIGINT(13) NOT NULL,
-  `last_time_unreachable`         BIGINT(13) NOT NULL,
-  `current_notification_number`   INT(11) UNSIGNED    DEFAULT 0,
-  `percent_state_change`          DOUBLE              DEFAULT 0,
-  `event_handler`                 VARCHAR(255),
-  `check_command`                 VARCHAR(255),
-  PRIMARY KEY (`hostname`)
+
+CREATE TABLE `statusengine_hostchecks`
+(
+    `hostname`              VARCHAR(255),
+    `state`                 SMALLINT(2) UNSIGNED DEFAULT 0,
+    `is_hardstate`          TINYINT(1) UNSIGNED  DEFAULT 0,
+    `start_time`            BIGINT(13) NOT NULL,
+    `end_time`              BIGINT(13) NOT NULL,
+    `output`                VARCHAR(1024),
+    `timeout`               SMALLINT(3) UNSIGNED DEFAULT 0,
+    `early_timeout`         TINYINT(1) UNSIGNED  DEFAULT 0,
+    `latency`               FLOAT                DEFAULT 0,
+    `execution_time`        FLOAT                DEFAULT 0,
+    `perfdata`              VARCHAR(1024),
+    `command`               VARCHAR(1024),
+    `current_check_attempt` SMALLINT(3) UNSIGNED DEFAULT 0,
+    `max_check_attempts`    SMALLINT(3) UNSIGNED DEFAULT 0,
+    `long_output`           VARCHAR(8192),
+    KEY `times` (`start_time`, `end_time`),
+    KEY `hostname` (`hostname`, `start_time`)
 )
-  ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_general_ci;
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_general_ci;
 
-CREATE TABLE `statusengine_servicestatus` (
-  `hostname`                      VARCHAR(255),
-  `service_description`           VARCHAR(255),
-  `status_update_time`            BIGINT(13) NOT NULL,
-  `output`                        VARCHAR(1024),
-  `long_output`                   VARCHAR(1024),
-  `perfdata`                      VARCHAR(1024),
-  `current_state`                 TINYINT(2) UNSIGNED DEFAULT 0,
-  `current_check_attempt`         TINYINT(3) UNSIGNED DEFAULT 0,
-  `max_check_attempts`            TINYINT(3) UNSIGNED DEFAULT 0,
-  `last_check`                    BIGINT(13) NOT NULL,
-  `next_check`                    BIGINT(13) NOT NULL,
-  `is_passive_check`              TINYINT(1) UNSIGNED DEFAULT 0,
-  `last_state_change`             BIGINT(13) NOT NULL,
-  `last_hard_state_change`        BIGINT(13) NOT NULL,
-  `last_hard_state`               TINYINT(2) UNSIGNED DEFAULT 0,
-  `is_hardstate`                  TINYINT(1) UNSIGNED DEFAULT 0,
-  `last_notification`             BIGINT(13) NOT NULL,
-  `next_notification`             BIGINT(13) NOT NULL,
-  `notifications_enabled`         TINYINT(1) UNSIGNED DEFAULT 0,
-  `problem_has_been_acknowledged` TINYINT(1) UNSIGNED DEFAULT 0,
-  `acknowledgement_type`          TINYINT(1) UNSIGNED DEFAULT 0,
-  `passive_checks_enabled`        TINYINT(1) UNSIGNED DEFAULT 0,
-  `active_checks_enabled`         TINYINT(1) UNSIGNED DEFAULT 0,
-  `event_handler_enabled`         TINYINT(1) UNSIGNED DEFAULT 0,
-  `flap_detection_enabled`        TINYINT(1) UNSIGNED DEFAULT 0,
-  `is_flapping`                   TINYINT(1) UNSIGNED DEFAULT 0,
-  `latency`                       FLOAT               DEFAULT 0,
-  `execution_time`                FLOAT               DEFAULT 0,
-  `scheduled_downtime_depth`      TINYINT(2) UNSIGNED DEFAULT 0,
-  `process_performance_data`      TINYINT(1) UNSIGNED DEFAULT 0,
-  `obsess_over_service`           TINYINT(1) UNSIGNED DEFAULT 0,
-  `normal_check_interval`         INT(11) UNSIGNED    DEFAULT 0,
-  `retry_check_interval`          INT(11) UNSIGNED    DEFAULT 0,
-  `check_timeperiod`              VARCHAR(255),
-  `node_name`                     VARCHAR(255),
-  last_time_ok                    BIGINT(13) NOT NULL,
-  last_time_warning               BIGINT(13) NOT NULL,
-  last_time_critical              BIGINT(13) NOT NULL,
-  last_time_unknown               BIGINT(13) NOT NULL,
-  `current_notification_number`   INT(11) UNSIGNED    DEFAULT 0,
-  `percent_state_change`          DOUBLE              DEFAULT 0,
-  `event_handler`                 VARCHAR(255),
-  `check_command`                 VARCHAR(255),
-  PRIMARY KEY (`hostname`, `service_description`),
-  KEY `current_state_node` (`current_state`, `node_name`),
-  KEY `issues` (`problem_has_been_acknowledged`, `scheduled_downtime_depth`, `current_state`),
-  KEY `service_description` (`service_description`)
-)
-  ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_general_ci;
-
-CREATE TABLE `statusengine_nodes` (
-  `node_name`       VARCHAR(255),
-  `node_version`    VARCHAR(255),
-  `node_start_time` BIGINT(13) NOT NULL,
-  PRIMARY KEY (`node_name`)
-)
-  ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_general_ci;
-
-CREATE TABLE `statusengine_tasks` (
-  `uuid`       VARCHAR(255),
-  `node_name`  VARCHAR(255),
-  `entry_time` BIGINT(13) NOT NULL,
-  `type`       VARCHAR(255),
-  `payload`    VARCHAR(8192),
-  KEY `node_name` (`node_name`),
-  KEY `uuid` (`uuid`)
-)
-  ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_general_ci;
-
-CREATE TABLE `statusengine_host_notifications` (
-  `hostname`     VARCHAR(255),
-  `contact_name` VARCHAR(1024),
-  `command_name` VARCHAR(1024),
-  `command_args` VARCHAR(1024),
-  `state`        TINYINT(2) UNSIGNED DEFAULT 0,
-  `start_time`   BIGINT(13) NOT NULL,
-  `end_time`     BIGINT(13) NOT NULL,
-  `reason_type`  TINYINT(3) UNSIGNED DEFAULT 0,
-  `output`       VARCHAR(1024),
-  `ack_author`   VARCHAR(255),
-  `ack_data`     VARCHAR(1024),
-  KEY `hostname` (`hostname`),
-  KEY `start_time` (`start_time`)
+CREATE TABLE `statusengine_servicechecks`
+(
+    `hostname`              VARCHAR(255),
+    `service_description`   VARCHAR(255),
+    `state`                 SMALLINT(2) UNSIGNED DEFAULT 0,
+    `is_hardstate`          TINYINT(1) UNSIGNED  DEFAULT 0,
+    `start_time`            BIGINT(13) NOT NULL,
+    `end_time`              BIGINT(13) NOT NULL,
+    `output`                VARCHAR(1024),
+    `timeout`               SMALLINT(3) UNSIGNED DEFAULT 0,
+    `early_timeout`         TINYINT(1) UNSIGNED  DEFAULT 0,
+    `latency`               FLOAT                DEFAULT 0,
+    `execution_time`        FLOAT                DEFAULT 0,
+    `perfdata`              VARCHAR(1024),
+    `command`               VARCHAR(1024),
+    `current_check_attempt` SMALLINT(3) UNSIGNED DEFAULT 0,
+    `max_check_attempts`    SMALLINT(3) UNSIGNED DEFAULT 0,
+    `long_output`           VARCHAR(8192),
+    KEY `servicename` (`hostname`, `service_description`, `start_time`)
 
 )
-  ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_general_ci;
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_general_ci;
 
-CREATE TABLE `statusengine_service_notifications` (
-  `hostname`            VARCHAR(255),
-  `service_description` VARCHAR(255),
-  `contact_name`        VARCHAR(1024),
-  `command_name`        VARCHAR(1024),
-  `command_args`        VARCHAR(1024),
-  `state`               TINYINT(2) UNSIGNED DEFAULT 0,
-  `start_time`          BIGINT(13) NOT NULL,
-  `end_time`            BIGINT(13) NOT NULL,
-  `reason_type`         TINYINT(3) UNSIGNED DEFAULT 0,
-  `output`              VARCHAR(1024),
-  `ack_author`          VARCHAR(255),
-  `ack_data`            VARCHAR(1024),
-  KEY `servicename` (`hostname`, `service_description`),
-  KEY `start_time` (`start_time`)
+CREATE TABLE `statusengine_hoststatus`
+(
+    `hostname`                      VARCHAR(255),
+    `status_update_time`            BIGINT(13) NOT NULL,
+    `output`                        VARCHAR(1024),
+    `long_output`                   VARCHAR(1024),
+    `perfdata`                      VARCHAR(1024),
+    `current_state`                 SMALLINT(2) UNSIGNED DEFAULT 0,
+    `current_check_attempt`         SMALLINT(3) UNSIGNED DEFAULT 0,
+    `max_check_attempts`            SMALLINT(3) UNSIGNED DEFAULT 0,
+    `last_check`                    BIGINT(13) NOT NULL,
+    `next_check`                    BIGINT(13) NOT NULL,
+    `is_passive_check`              TINYINT(1) UNSIGNED  DEFAULT 0,
+    `last_state_change`             BIGINT(13) NOT NULL,
+    `last_hard_state_change`        BIGINT(13) NOT NULL,
+    `last_hard_state`               SMALLINT(2) UNSIGNED DEFAULT 0,
+    `is_hardstate`                  TINYINT(1) UNSIGNED  DEFAULT 0,
+    `last_notification`             BIGINT(13) NOT NULL,
+    `next_notification`             BIGINT(13) NOT NULL,
+    `notifications_enabled`         TINYINT(1) UNSIGNED  DEFAULT 0,
+    `problem_has_been_acknowledged` TINYINT(1) UNSIGNED  DEFAULT 0,
+    `acknowledgement_type`          SMALLINT(2) UNSIGNED DEFAULT 0,
+    `passive_checks_enabled`        TINYINT(1) UNSIGNED  DEFAULT 0,
+    `active_checks_enabled`         TINYINT(1) UNSIGNED  DEFAULT 0,
+    `event_handler_enabled`         TINYINT(1) UNSIGNED  DEFAULT 0,
+    `flap_detection_enabled`        TINYINT(1) UNSIGNED  DEFAULT 0,
+    `is_flapping`                   TINYINT(1) UNSIGNED  DEFAULT 0,
+    `latency`                       FLOAT                DEFAULT 0,
+    `execution_time`                FLOAT                DEFAULT 0,
+    `scheduled_downtime_depth`      SMALLINT(2) UNSIGNED DEFAULT 0,
+    `process_performance_data`      TINYINT(1) UNSIGNED  DEFAULT 0,
+    `obsess_over_host`              TINYINT(1) UNSIGNED  DEFAULT 0,
+    `normal_check_interval`         INT(11) UNSIGNED     DEFAULT 0,
+    `retry_check_interval`          INT(11) UNSIGNED     DEFAULT 0,
+    `check_timeperiod`              VARCHAR(255),
+    `node_name`                     VARCHAR(255),
+    `last_time_up`                  BIGINT(13) NOT NULL,
+    `last_time_down`                BIGINT(13) NOT NULL,
+    `last_time_unreachable`         BIGINT(13) NOT NULL,
+    `current_notification_number`   INT(11) UNSIGNED     DEFAULT 0,
+    `percent_state_change`          DOUBLE               DEFAULT 0,
+    `event_handler`                 VARCHAR(255),
+    `check_command`                 VARCHAR(255),
+    PRIMARY KEY (`hostname`)
+)
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_general_ci;
+
+CREATE TABLE `statusengine_servicestatus`
+(
+    `hostname`                      VARCHAR(255),
+    `service_description`           VARCHAR(255),
+    `status_update_time`            BIGINT(13) NOT NULL,
+    `output`                        VARCHAR(1024),
+    `long_output`                   VARCHAR(1024),
+    `perfdata`                      VARCHAR(1024),
+    `current_state`                 SMALLINT(2) UNSIGNED DEFAULT 0,
+    `current_check_attempt`         SMALLINT(3) UNSIGNED DEFAULT 0,
+    `max_check_attempts`            SMALLINT(3) UNSIGNED DEFAULT 0,
+    `last_check`                    BIGINT(13) NOT NULL,
+    `next_check`                    BIGINT(13) NOT NULL,
+    `is_passive_check`              TINYINT(1) UNSIGNED  DEFAULT 0,
+    `last_state_change`             BIGINT(13) NOT NULL,
+    `last_hard_state_change`        BIGINT(13) NOT NULL,
+    `last_hard_state`               SMALLINT(2) UNSIGNED DEFAULT 0,
+    `is_hardstate`                  TINYINT(1) UNSIGNED  DEFAULT 0,
+    `last_notification`             BIGINT(13) NOT NULL,
+    `next_notification`             BIGINT(13) NOT NULL,
+    `notifications_enabled`         TINYINT(1) UNSIGNED  DEFAULT 0,
+    `problem_has_been_acknowledged` TINYINT(1) UNSIGNED  DEFAULT 0,
+    `acknowledgement_type`          TINYINT(1) UNSIGNED  DEFAULT 0,
+    `passive_checks_enabled`        TINYINT(1) UNSIGNED  DEFAULT 0,
+    `active_checks_enabled`         TINYINT(1) UNSIGNED  DEFAULT 0,
+    `event_handler_enabled`         TINYINT(1) UNSIGNED  DEFAULT 0,
+    `flap_detection_enabled`        TINYINT(1) UNSIGNED  DEFAULT 0,
+    `is_flapping`                   TINYINT(1) UNSIGNED  DEFAULT 0,
+    `latency`                       FLOAT                DEFAULT 0,
+    `execution_time`                FLOAT                DEFAULT 0,
+    `scheduled_downtime_depth`      SMALLINT(2) UNSIGNED DEFAULT 0,
+    `process_performance_data`      TINYINT(1) UNSIGNED  DEFAULT 0,
+    `obsess_over_service`           TINYINT(1) UNSIGNED  DEFAULT 0,
+    `normal_check_interval`         INT(11) UNSIGNED     DEFAULT 0,
+    `retry_check_interval`          INT(11) UNSIGNED     DEFAULT 0,
+    `check_timeperiod`              VARCHAR(255),
+    `node_name`                     VARCHAR(255),
+    last_time_ok                    BIGINT(13) NOT NULL,
+    last_time_warning               BIGINT(13) NOT NULL,
+    last_time_critical              BIGINT(13) NOT NULL,
+    last_time_unknown               BIGINT(13) NOT NULL,
+    `current_notification_number`   INT(11) UNSIGNED     DEFAULT 0,
+    `percent_state_change`          DOUBLE               DEFAULT 0,
+    `event_handler`                 VARCHAR(255),
+    `check_command`                 VARCHAR(255),
+    PRIMARY KEY (`hostname`, `service_description`),
+    KEY `current_state_node` (`current_state`, `node_name`),
+    KEY `issues` (`problem_has_been_acknowledged`, `scheduled_downtime_depth`, `current_state`),
+    KEY `service_description` (`service_description`)
+)
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_general_ci;
+
+CREATE TABLE `statusengine_nodes`
+(
+    `node_name`       VARCHAR(255),
+    `node_version`    VARCHAR(255),
+    `node_start_time` BIGINT(13) NOT NULL,
+    PRIMARY KEY (`node_name`)
+)
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_general_ci;
+
+CREATE TABLE `statusengine_tasks`
+(
+    `uuid`       VARCHAR(255),
+    `node_name`  VARCHAR(255),
+    `entry_time` BIGINT(13) NOT NULL,
+    `type`       VARCHAR(255),
+    `payload`    VARCHAR(8192),
+    KEY `node_name` (`node_name`),
+    KEY `uuid` (`uuid`)
+)
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_general_ci;
+
+CREATE TABLE `statusengine_host_notifications`
+(
+    `hostname`     VARCHAR(255),
+    `contact_name` VARCHAR(1024),
+    `command_name` VARCHAR(1024),
+    `command_args` VARCHAR(1024),
+    `state`        SMALLINT(2) UNSIGNED DEFAULT 0,
+    `start_time`   BIGINT(13) NOT NULL,
+    `end_time`     BIGINT(13) NOT NULL,
+    `reason_type`  SMALLINT(3) UNSIGNED DEFAULT 0,
+    `output`       VARCHAR(1024),
+    `ack_author`   VARCHAR(255),
+    `ack_data`     VARCHAR(1024),
+    KEY `hostname` (`hostname`),
+    KEY `start_time` (`start_time`)
 
 )
-  ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_general_ci;
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_general_ci;
 
-CREATE TABLE `statusengine_host_acknowledgements` (
-  `hostname`             VARCHAR(255),
-  `state`                TINYINT(2) UNSIGNED DEFAULT 0,
-  `author_name`          VARCHAR(255),
-  `comment_data`         VARCHAR(1024),
-  `entry_time`           BIGINT(13) NOT NULL,
-  `acknowledgement_type` TINYINT(2) UNSIGNED DEFAULT 0,
-  `is_sticky`            TINYINT(1) UNSIGNED DEFAULT 0,
-  `persistent_comment`   TINYINT(1) UNSIGNED DEFAULT 0,
-  `notify_contacts`      TINYINT(1) UNSIGNED DEFAULT 0,
-  KEY `hostname` (`hostname`),
-  KEY `entry_time` (`entry_time`)
+CREATE TABLE `statusengine_service_notifications`
+(
+    `hostname`            VARCHAR(255),
+    `service_description` VARCHAR(255),
+    `contact_name`        VARCHAR(1024),
+    `command_name`        VARCHAR(1024),
+    `command_args`        VARCHAR(1024),
+    `state`               SMALLINT(2) UNSIGNED DEFAULT 0,
+    `start_time`          BIGINT(13) NOT NULL,
+    `end_time`            BIGINT(13) NOT NULL,
+    `reason_type`         SMALLINT(3) UNSIGNED DEFAULT 0,
+    `output`              VARCHAR(1024),
+    `ack_author`          VARCHAR(255),
+    `ack_data`            VARCHAR(1024),
+    KEY `servicename` (`hostname`, `service_description`),
+    KEY `start_time` (`start_time`)
 
 )
-  ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_general_ci;
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_general_ci;
 
-CREATE TABLE `statusengine_service_acknowledgements` (
-  `hostname`             VARCHAR(255),
-  `service_description`  VARCHAR(255),
-  `state`                TINYINT(2) UNSIGNED DEFAULT 0,
-  `author_name`          VARCHAR(255),
-  `comment_data`         VARCHAR(1024),
-  `entry_time`           BIGINT(13) NOT NULL,
-  `acknowledgement_type` TINYINT(2) UNSIGNED DEFAULT 0,
-  `is_sticky`            TINYINT(1) UNSIGNED DEFAULT 0,
-  `persistent_comment`   TINYINT(1) UNSIGNED DEFAULT 0,
-  `notify_contacts`      TINYINT(1) UNSIGNED DEFAULT 0,
-  KEY `servicename` (`hostname`, `service_description`),
-  KEY `entry_time` (`entry_time`),
-  KEY `servicedesc_time` (`service_description`, `entry_time`)
+CREATE TABLE `statusengine_host_acknowledgements`
+(
+    `hostname`             VARCHAR(255),
+    `state`                SMALLINT(2) UNSIGNED DEFAULT 0,
+    `author_name`          VARCHAR(255),
+    `comment_data`         VARCHAR(1024),
+    `entry_time`           BIGINT(13) NOT NULL,
+    `acknowledgement_type` SMALLINT(2) UNSIGNED DEFAULT 0,
+    `is_sticky`            TINYINT(1) UNSIGNED  DEFAULT 0,
+    `persistent_comment`   TINYINT(1) UNSIGNED  DEFAULT 0,
+    `notify_contacts`      TINYINT(1) UNSIGNED  DEFAULT 0,
+    KEY `hostname` (`hostname`),
+    KEY `entry_time` (`entry_time`)
+
 )
-  ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_general_ci;
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_general_ci;
 
-CREATE TABLE `statusengine_users` (
-  `username` VARCHAR(255),
-  `password` VARCHAR(255),
-  KEY `username` (`username`, `password`)
+CREATE TABLE `statusengine_service_acknowledgements`
+(
+    `hostname`             VARCHAR(255),
+    `service_description`  VARCHAR(255),
+    `state`                SMALLINT(2) UNSIGNED DEFAULT 0,
+    `author_name`          VARCHAR(255),
+    `comment_data`         VARCHAR(1024),
+    `entry_time`           BIGINT(13) NOT NULL,
+    `acknowledgement_type` SMALLINT(2) UNSIGNED DEFAULT 0,
+    `is_sticky`            TINYINT(1) UNSIGNED  DEFAULT 0,
+    `persistent_comment`   TINYINT(1) UNSIGNED  DEFAULT 0,
+    `notify_contacts`      TINYINT(1) UNSIGNED  DEFAULT 0,
+    KEY `servicename` (`hostname`, `service_description`),
+    KEY `entry_time` (`entry_time`),
+    KEY `servicedesc_time` (`service_description`, `entry_time`)
 )
-  ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_general_ci;
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_general_ci;
 
-CREATE TABLE `statusengine_host_downtimehistory` (
-  `hostname`             VARCHAR(255),
-  `entry_time`           BIGINT(13) NOT NULL,
-  `author_name`          VARCHAR(255),
-  `comment_data`         VARCHAR(1024),
-  `internal_downtime_id` INT(11) UNSIGNED,
-  `triggered_by_id`      INT(11) UNSIGNED,
-  `is_fixed`             TINYINT(1) UNSIGNED DEFAULT 0,
-  `duration`             INT(11) UNSIGNED,
-  `scheduled_start_time` BIGINT(13) NOT NULL,
-  `scheduled_end_time`   BIGINT(13) NOT NULL,
-  `was_started`          TINYINT(1) UNSIGNED DEFAULT 0,
-  `actual_start_time`    BIGINT(13) NOT NULL,
-  `actual_end_time`      BIGINT(13) NOT NULL,
-  `was_cancelled`        TINYINT(1) UNSIGNED DEFAULT 0,
-  `node_name`            VARCHAR(255),
-  PRIMARY KEY (`hostname`, `node_name`, `scheduled_start_time`, `internal_downtime_id`),
-  KEY `list` (`hostname`, `scheduled_start_time`, `scheduled_end_time`, `was_cancelled`)
+CREATE TABLE `statusengine_users`
+(
+    `username` VARCHAR(255),
+    `password` VARCHAR(255),
+    KEY `username` (`username`, `password`)
 )
-  ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_general_ci;
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_general_ci;
 
-CREATE TABLE `statusengine_host_scheduleddowntimes` (
-  `hostname`             VARCHAR(255),
-  `entry_time`           BIGINT(13) NOT NULL,
-  `author_name`          VARCHAR(255),
-  `comment_data`         VARCHAR(1024),
-  `internal_downtime_id` INT(11) UNSIGNED,
-  `triggered_by_id`      INT(11) UNSIGNED,
-  `is_fixed`             TINYINT(1) UNSIGNED DEFAULT 0,
-  `duration`             INT(11) UNSIGNED,
-  `scheduled_start_time` BIGINT(13) NOT NULL,
-  `scheduled_end_time`   BIGINT(13) NOT NULL,
-  `was_started`          TINYINT(1) UNSIGNED DEFAULT 0,
-  `actual_start_time`    BIGINT(13) NOT NULL,
-  `node_name`            VARCHAR(255),
-  PRIMARY KEY (`hostname`, `node_name`, `scheduled_start_time`, `internal_downtime_id`)
+CREATE TABLE `statusengine_host_downtimehistory`
+(
+    `hostname`             VARCHAR(255),
+    `entry_time`           BIGINT(13) NOT NULL,
+    `author_name`          VARCHAR(255),
+    `comment_data`         VARCHAR(1024),
+    `internal_downtime_id` INT(11) UNSIGNED,
+    `triggered_by_id`      INT(11) UNSIGNED,
+    `is_fixed`             TINYINT(1) UNSIGNED DEFAULT 0,
+    `duration`             INT(11) UNSIGNED,
+    `scheduled_start_time` BIGINT(13) NOT NULL,
+    `scheduled_end_time`   BIGINT(13) NOT NULL,
+    `was_started`          TINYINT(1) UNSIGNED DEFAULT 0,
+    `actual_start_time`    BIGINT(13) NOT NULL,
+    `actual_end_time`      BIGINT(13) NOT NULL,
+    `was_cancelled`        TINYINT(1) UNSIGNED DEFAULT 0,
+    `node_name`            VARCHAR(255),
+    PRIMARY KEY (`hostname`, `node_name`, `scheduled_start_time`, `internal_downtime_id`),
+    KEY `list` (`hostname`, `scheduled_start_time`, `scheduled_end_time`, `was_cancelled`)
 )
-  ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_general_ci;
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_general_ci;
 
-CREATE TABLE `statusengine_service_downtimehistory` (
-  `hostname`             VARCHAR(255),
-  `service_description`  VARCHAR(255),
-  `entry_time`           BIGINT(13) NOT NULL,
-  `author_name`          VARCHAR(255),
-  `comment_data`         VARCHAR(1024),
-  `internal_downtime_id` INT(11) UNSIGNED,
-  `triggered_by_id`      INT(11) UNSIGNED,
-  `is_fixed`             TINYINT(1) UNSIGNED DEFAULT 0,
-  `duration`             INT(11) UNSIGNED,
-  `scheduled_start_time` BIGINT(13) NOT NULL,
-  `scheduled_end_time`   BIGINT(13) NOT NULL,
-  `was_started`          TINYINT(1) UNSIGNED DEFAULT 0,
-  `actual_start_time`    BIGINT(13) NOT NULL,
-  `actual_end_time`      BIGINT(13) NOT NULL,
-  `was_cancelled`        TINYINT(1) UNSIGNED DEFAULT 0,
-  `node_name`            VARCHAR(255),
-  PRIMARY KEY (`hostname`, `service_description`, `node_name`, `scheduled_start_time`, `internal_downtime_id`),
-  KEY `report` (`service_description`, `scheduled_start_time`, `scheduled_end_time`, `was_cancelled`)
+CREATE TABLE `statusengine_host_scheduleddowntimes`
+(
+    `hostname`             VARCHAR(255),
+    `entry_time`           BIGINT(13) NOT NULL,
+    `author_name`          VARCHAR(255),
+    `comment_data`         VARCHAR(1024),
+    `internal_downtime_id` INT(11) UNSIGNED,
+    `triggered_by_id`      INT(11) UNSIGNED,
+    `is_fixed`             TINYINT(1) UNSIGNED DEFAULT 0,
+    `duration`             INT(11) UNSIGNED,
+    `scheduled_start_time` BIGINT(13) NOT NULL,
+    `scheduled_end_time`   BIGINT(13) NOT NULL,
+    `was_started`          TINYINT(1) UNSIGNED DEFAULT 0,
+    `actual_start_time`    BIGINT(13) NOT NULL,
+    `node_name`            VARCHAR(255),
+    PRIMARY KEY (`hostname`, `node_name`, `scheduled_start_time`, `internal_downtime_id`)
 )
-  ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_general_ci;
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_general_ci;
 
-CREATE TABLE `statusengine_service_scheduleddowntimes` (
-  `hostname`             VARCHAR(255),
-  `service_description`  VARCHAR(255),
-  `entry_time`           BIGINT(13) NOT NULL,
-  `author_name`          VARCHAR(255),
-  `comment_data`         VARCHAR(1024),
-  `internal_downtime_id` INT(11) UNSIGNED,
-  `triggered_by_id`      INT(11) UNSIGNED,
-  `is_fixed`             TINYINT(1) UNSIGNED DEFAULT 0,
-  `duration`             INT(11) UNSIGNED,
-  `scheduled_start_time` BIGINT(13) NOT NULL,
-  `scheduled_end_time`   BIGINT(13) NOT NULL,
-  `was_started`          TINYINT(1) UNSIGNED DEFAULT 0,
-  `actual_start_time`    BIGINT(13) NOT NULL,
-  `node_name`            VARCHAR(255),
-  PRIMARY KEY (`hostname`, `service_description`, `node_name`, `scheduled_start_time`, `internal_downtime_id`)
+CREATE TABLE `statusengine_service_downtimehistory`
+(
+    `hostname`             VARCHAR(255),
+    `service_description`  VARCHAR(255),
+    `entry_time`           BIGINT(13) NOT NULL,
+    `author_name`          VARCHAR(255),
+    `comment_data`         VARCHAR(1024),
+    `internal_downtime_id` INT(11) UNSIGNED,
+    `triggered_by_id`      INT(11) UNSIGNED,
+    `is_fixed`             TINYINT(1) UNSIGNED DEFAULT 0,
+    `duration`             INT(11) UNSIGNED,
+    `scheduled_start_time` BIGINT(13) NOT NULL,
+    `scheduled_end_time`   BIGINT(13) NOT NULL,
+    `was_started`          TINYINT(1) UNSIGNED DEFAULT 0,
+    `actual_start_time`    BIGINT(13) NOT NULL,
+    `actual_end_time`      BIGINT(13) NOT NULL,
+    `was_cancelled`        TINYINT(1) UNSIGNED DEFAULT 0,
+    `node_name`            VARCHAR(255),
+    PRIMARY KEY (`hostname`, `service_description`, `node_name`, `scheduled_start_time`, `internal_downtime_id`),
+    KEY `report` (`service_description`, `scheduled_start_time`, `scheduled_end_time`, `was_cancelled`)
 )
-  ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_general_ci;
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_general_ci;
 
-CREATE TABLE `statusengine_perfdata` (
-  `hostname`            VARCHAR(255),
-  `service_description` VARCHAR(255),
-  `label`               VARCHAR(255),
-  `timestamp`           BIGINT(20) NOT NULL,
-  `timestamp_unix`      BIGINT(13) NOT NULL,
-  `value`               DOUBLE,
-  `unit`                VARCHAR(10),
-  KEY `metric` (`hostname`, `service_description`, `label`, `timestamp_unix`),
-  KEY `timestamp_unix` (`timestamp_unix`)
+CREATE TABLE `statusengine_service_scheduleddowntimes`
+(
+    `hostname`             VARCHAR(255),
+    `service_description`  VARCHAR(255),
+    `entry_time`           BIGINT(13) NOT NULL,
+    `author_name`          VARCHAR(255),
+    `comment_data`         VARCHAR(1024),
+    `internal_downtime_id` INT(11) UNSIGNED,
+    `triggered_by_id`      INT(11) UNSIGNED,
+    `is_fixed`             TINYINT(1) UNSIGNED DEFAULT 0,
+    `duration`             INT(11) UNSIGNED,
+    `scheduled_start_time` BIGINT(13) NOT NULL,
+    `scheduled_end_time`   BIGINT(13) NOT NULL,
+    `was_started`          TINYINT(1) UNSIGNED DEFAULT 0,
+    `actual_start_time`    BIGINT(13) NOT NULL,
+    `node_name`            VARCHAR(255),
+    PRIMARY KEY (`hostname`, `service_description`, `node_name`, `scheduled_start_time`, `internal_downtime_id`)
 )
-  ENGINE = InnoDB
-  DEFAULT CHARSET = utf8
-  COLLATE = utf8_general_ci;
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_general_ci;
 
-CREATE TABLE IF NOT EXISTS `statusengine_dbversion` (
-  `id`        INT(13) NOT NULL,
-  `dbversion` VARCHAR(255) DEFAULT '3.0.0',
-  PRIMARY KEY (`id`)
+CREATE TABLE `statusengine_perfdata`
+(
+    `hostname`            VARCHAR(255),
+    `service_description` VARCHAR(255),
+    `label`               VARCHAR(255),
+    `timestamp`           BIGINT(20) NOT NULL,
+    `timestamp_unix`      BIGINT(13) NOT NULL,
+    `value`               DOUBLE,
+    `unit`                VARCHAR(10),
+    KEY `metric` (`hostname`, `service_description`, `label`, `timestamp_unix`),
+    KEY `timestamp_unix` (`timestamp_unix`)
 )
-  ENGINE = InnoDB
-  DEFAULT CHARSET = utf8;
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_general_ci;
 
-INSERT INTO `statusengine_dbversion` (`id`, `dbversion`) VALUES (1, '3.1.0');
+CREATE TABLE IF NOT EXISTS `statusengine_dbversion`
+(
+    `id`        INT(13) NOT NULL,
+    `dbversion` VARCHAR(255) DEFAULT '3.0.0',
+    PRIMARY KEY (`id`)
+)
+    ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4;
+
+INSERT INTO `statusengine_dbversion` (`id`, `dbversion`)
+VALUES (1, '3.1.0');

--- a/lib/mysql.sql
+++ b/lib/mysql.sql
@@ -1,5 +1,13 @@
 -- THIS IS NOT A CrateDB.sql FILE
 -- THIS FILE WAS CREATED FOR MySQL
+--
+-- The usage of this file is DEPRECATED and support for plain SQL dumps will be dropped soon!
+-- Please use the following command to create and update your database
+-- /opt/statusengine/worker/bin/Console.php database --update
+--
+-- Use the --dry-run option to see all SQL statements that will be executed without touching your live database
+-- /opt/statusengine/worker/bin/Console.php database --update --dry-run
+--
 
 CREATE TABLE IF NOT EXISTS `statusengine_logentries`
 (

--- a/src/Console/Database.php
+++ b/src/Console/Database.php
@@ -1,0 +1,316 @@
+<?php
+/**
+ * Statusengine Worker
+ * Copyright (C) 2016-2019  Daniel Ziegler
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Statusengine\Console;
+
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Index;
+use Doctrine\DBAL\Schema\Schema;
+use Statusengine\BackendSelector;
+use Statusengine\BulkInsertObjectStore;
+use Statusengine\Config;
+use Statusengine\StorageBackend;
+use Statusengine\Syslog;
+use Statusengine\ValueObjects\NodeName;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\Output;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+class Database extends Command {
+
+    /**
+     * @var Config
+     */
+    private $Config;
+
+    /**
+     * @var Syslog
+     */
+    private $Syslog;
+
+    /**
+     * @var StorageBackend
+     */
+    private $StorageBackend;
+
+
+    protected function configure() {
+        $this
+            // the name of the command (the part after "bin/console")
+            ->setName('database')
+            // the short description shown while running "php bin/console list"
+            ->setDescription('Create and update database schema')
+            // the full command description shown when running the command with
+            // the "--help" option
+            ->setHelp("CLI command to create and update the statusengine database schema");
+
+        $this->addOption('dump', null, InputOption::VALUE_OPTIONAL, 'Will dump the current SQL schema fromm the database to a PHP file.', false);
+        $this->addOption('update', null, InputOption::VALUE_OPTIONAL, 'Will the database schema.', false);
+
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output) {
+        $this->Config = new Config();
+        $this->Syslog = new Syslog($this->Config);
+
+
+        $BulkInsertObjectStore = new BulkInsertObjectStore(
+            1,
+            1
+        );
+        $BackendSelector = new BackendSelector($this->Config, $BulkInsertObjectStore, $this->Syslog);
+        $this->StorageBackend = $BackendSelector->getStorageBackend();
+
+        if ($this->Config->isMysqlEnabled()) {
+            $mysqlConfig = $this->Config->getMysqlConfig();
+
+            $connectionParams = [
+                'dbname'   => $mysqlConfig['database'],
+                'user'     => $mysqlConfig['username'],
+                'password' => $mysqlConfig['password'],
+                'host'     => $mysqlConfig['host'],
+                'port'     => $mysqlConfig['port'],
+                //'charset'  => 'UTF-8',
+                'driver'   => 'pdo_mysql',
+            ];
+        }
+
+
+        if ($this->Config->isCrateEnabled()) {
+            $crateConfig = $this->Config->getCrateConfig();
+            $firstHost = $crateConfig[0];
+
+            $config = explode(':', $firstHost);
+
+            $connectionParams = [
+                'user'        => null,
+                'password'    => null,
+                'host'        => $config[0],
+                'port'        => $config[1],
+                'driverClass' => 'Crate\DBAL\Driver\PDOCrate\Driver',
+            ];
+        }
+
+        $connection = DriverManager::getConnection($connectionParams);
+        $platform = $connection->getDatabasePlatform();
+
+        $SchemaManager = $connection->getSchemaManager();
+
+        $schema = $SchemaManager->createSchema();
+
+
+        //https://stackoverflow.com/a/50518342
+        if ($input->getOption('dump') === null) {
+            $output->writeln('Dump database schema to PHP code...');
+            if ($this->Config->isMysqlEnabled()) {
+                $filename = $this->dumpMySQLSchema($schema);
+            }
+
+            if ($this->Config->isCrateEnabled()) {
+                $filename = $this->dumpCrateDBSchema($schema);
+            }
+
+            $output->writeln('Schema written to: ' . $filename);
+        }
+
+        if ($input->getOption('update') === null) {
+            $output->writeln('Start updating your database...');
+            $this->updateDatabase($schema, $connection, $output);
+        }
+
+    }
+
+    /**
+     * @param Schema $schema
+     * @return string
+     */
+    public function dumpMySQLSchema(Schema $schema) {
+        $file = fopen($this->getFullFileName(), 'w+');
+
+        $data = '<?php' . PHP_EOL . PHP_EOL;
+        $data .= 'use Doctrine\DBAL\Schema\Schema;' . PHP_EOL;
+
+        $data .= PHP_EOL . PHP_EOL;
+
+
+        $data .= 'require_once __DIR__ . DIRECTORY_SEPARATOR . \'..\' . DIRECTORY_SEPARATOR . \'bootstrap.php\';' . PHP_EOL;
+        $data .= '$schema = new Schema();' . PHP_EOL . PHP_EOL;
+
+
+        foreach ($schema->getTables() as $table) {
+            /** @var $table \Doctrine\DBAL\Schema\Table */
+
+            $data .= sprintf('/****************************************%s', PHP_EOL);
+            $data .= sprintf(' * Define: %s%s', $table->getName(), PHP_EOL);
+            $data .= sprintf(' ***************************************/%s', PHP_EOL);
+
+            $data .= sprintf('$table = $schema->createTable("%s");%s', $table->getName(), PHP_EOL);
+
+            $tableOptions = $table->getOptions();
+
+            $data .= sprintf('$table->addOption("engine" , "%s");%s', $tableOptions['engine'], PHP_EOL);
+            $data .= sprintf('$table->addOption("collation" , "%s");%s', $tableOptions['collation'], PHP_EOL);
+            $data .= sprintf('$table->addOption("comment" , "%s");%s', $tableOptions['comment'], PHP_EOL);
+
+
+            foreach ($table->getColumns() as $column) {
+                $default = null;
+                if (is_numeric($column->getDefault())) {
+                    $default = $column->getDefault();
+                } else if ($column->getDefault() !== null) {
+                    $default = $column->getDefault();
+                }
+
+                $options = [
+                    'unsigned'      => $column->getUnsigned(),
+                    'autoincrement' => $column->getAutoincrement(),
+                    'notnull'       => $column->getNotnull(),
+                    'default'       => $default
+                ];
+
+                if ($column->getLength()) {
+                    $options['length'] = $column->getLength();
+                }
+
+                $data .= sprintf('$table->addColumn("%s", "%s", %s);%s',
+                    $column->getName(),
+                    $column->getType()->getName(),
+                    var_export($options, true),
+                    PHP_EOL
+                );
+
+            }
+
+            $primaryKey = $table->getPrimaryKey();
+            if ($primaryKey) {
+                $columns = $this->makeArrayIfString($primaryKey->getColumns());
+                $data .= sprintf('$table->setPrimaryKey(%s);%s',
+                    '[' . PHP_EOL . '    "' . implode('", ' . PHP_EOL . '    "', $columns) . '"' . PHP_EOL . ']',
+                    PHP_EOL
+                );
+            }
+
+
+            foreach ($table->getIndexes() as $index) {
+                /** @var $index Index */
+                if ($index->isPrimary()) {
+                    continue;
+                }
+
+                $columns = $this->makeArrayIfString($index->getColumns());
+
+                if ($index->isUnique()) {
+                    $data .= sprintf('$table->addUniqueIndex(%s, "%s");%s',
+                        '[' . PHP_EOL . '    "' . implode('", ' . PHP_EOL . '    "', $columns) . '"' . PHP_EOL . ']',
+                        $index->getName(),
+                        PHP_EOL
+                    );
+                } else {
+                    $data .= sprintf('$table->addIndex(%s, "%s");%s',
+                        '[' . PHP_EOL . '    "' . implode('", ' . PHP_EOL . '    "', $columns) . '"' . PHP_EOL . ']',
+                        $index->getName(),
+                        PHP_EOL
+                    );
+                }
+            }
+
+            $data .= PHP_EOL . PHP_EOL . PHP_EOL;
+        }
+
+        $data .= 'return $schema;' . PHP_EOL;
+
+        fwrite($file, $data);
+        fclose($file);
+
+        return $this->getFullFileName();
+    }
+
+    /**
+     * @param Schema $schema
+     * @return string
+     */
+    public function dumpCrateDBSchema(Schema $schema) {
+        //https://github.com/crate/crate-dbal/issues/75
+        throw new \RuntimeException("CrateDB driver don't have sharts and primary key implemented");
+    }
+
+    public function updateDatabase(Schema $fromSchema, Connection $connection, OutputInterface $output) {
+        if (!file_exists($this->getFullFileName())) {
+            throw new \RuntimeException(
+                sprintf('File not found: %s', $this->getFullFileName())
+            );
+        }
+
+        $toSchema = require_once $this->getFullFileName();
+
+        $sql = $fromSchema->getMigrateToSql($toSchema, $connection->getDatabasePlatform());
+
+        if (empty($sql)) {
+            $output->writeln('<info>Database schema is up to date</info>');
+            return;
+        }
+
+        foreach ($sql as $query) {
+            $output->writeln('<comment>' . $query . '</comment>');
+            $stmt = $connection->query($query);
+            $stmt->execute();
+        }
+
+        $output->writeln('<info>Database schema updated successfully</info>');
+    }
+
+    /**
+     * @return string
+     */
+    private function getFileName() {
+        $filename = 'mysql.php';
+        if ($this->Config->isCrateEnabled()) {
+            $filename = 'cratedb.php';
+        }
+        return $filename;
+    }
+
+    /**
+     * @return string
+     */
+    private function getFullFileName() {
+        return __DIR__ . DS . '..' . DS . '..' . DS . 'lib' . DS . $this->getFileName();
+    }
+
+    /**
+     * @param string|array $strOrArray
+     * @return array
+     */
+    private function makeArrayIfString($strOrArray) {
+        if (is_array($strOrArray)) {
+            return $strOrArray;
+        }
+
+        return [$strOrArray];
+    }
+
+}

--- a/src/Console/Database.php
+++ b/src/Console/Database.php
@@ -52,6 +52,8 @@ use Symfony\Component\Console\Input\InputArgument;
  */
 class Database extends Command {
 
+    const DB_VERSION = '3.7.0';
+
     /**
      * @var Config
      */
@@ -301,6 +303,16 @@ class Database extends Command {
                     $output->writeln('<error>' . $e->getMessage() . '</error>');
                 }
                 unset($stmt);
+            }
+        }
+
+        $query = 'INSERT INTO statusengine_dbversion (id, dbversion)VALUES(1, \'' . self::DB_VERSION . '\') ON DUPLICATE KEY UPDATE dbversion=\'' . self::DB_VERSION . '\'';
+        $output->writeln('<comment>' . $query . '</comment>');
+        if ($dryrun === false) {
+            try {
+                $stmt = $connection->query($query);
+            } catch (\Exception $e) {
+                $output->writeln('<error>' . $e->getMessage() . '</error>');
             }
         }
 

--- a/src/Console/Database.php
+++ b/src/Console/Database.php
@@ -284,15 +284,19 @@ class Database extends Command {
 
         foreach ($sql as $query) {
             $output->writeln('<comment>' . $query . '</comment>');
-            if($dryrun === false) {
-                $stmt = $connection->query($query);
-                $stmt->execute();
+            if ($dryrun === false) {
+                try {
+                    $stmt = $connection->query($query);
+                } catch (\Exception $e) {
+                    $output->writeln('<error>' . $e->getMessage() . '</error>');
+                }
+                unset($stmt);
             }
         }
 
-        if($dryrun === false) {
+        if ($dryrun === false) {
             $output->writeln('<info>Database schema updated successfully</info>');
-        }else{
+        } else {
             $output->writeln('<info>No modifications where done to database!!!</info>');
         }
     }

--- a/src/Console/Database.php
+++ b/src/Console/Database.php
@@ -40,6 +40,16 @@ use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
+/**
+ * Class Database
+ * @package Statusengine\Console
+ *
+ * Dump current database schema to php file
+ * bin/Console.php database --dump
+ *
+ * Patch current database schema to schema defined in the php file
+ * bin/Console.php database --update --dry-run
+ */
 class Database extends Command {
 
     /**


### PR DESCRIPTION
I have added primary keys to the MySQL schema to avoid ordering by internal InnoDB columns like `DB_ROW_ID`.
With these primary keys the records get ordered by hostname and timestamp. This will speed up select queries.

I only made this changes to the mysql schema because CrateDB will work differently i guess.

In addition the schema for MySQL is now managed by DBAL.

```
$ bin/Console.php database --update --dry-run                                                                                                                                                                                      (DBAL|✚2…)
Start updating your database...
ALTER TABLE statusengine_dbversion CHANGE id id INT AUTO_INCREMENT NOT NULL
ALTER TABLE statusengine_host_acknowledgements CHANGE state state SMALLINT UNSIGNED DEFAULT 0, CHANGE acknowledgement_type acknowledgement_type SMALLINT UNSIGNED DEFAULT 0
ALTER TABLE statusengine_host_notifications CHANGE state state SMALLINT UNSIGNED DEFAULT 0, CHANGE reason_type reason_type SMALLINT UNSIGNED DEFAULT 0
DROP INDEX hostname_time ON statusengine_host_statehistory
ALTER TABLE statusengine_host_statehistory CHANGE hostname hostname VARCHAR(255) NOT NULL, CHANGE state state SMALLINT UNSIGNED DEFAULT 0, CHANGE current_check_attempt current_check_attempt SMALLINT UNSIGNED DEFAULT 0, CHANGE max_check_attempts max_check_attempts SMALLINT UNSIGNED DEFAULT 0, CHANGE last_state last_state SMALLINT UNSIGNED DEFAULT 0, CHANGE last_hard_state last_hard_state SMALLINT UNSIGNED DEFAULT 0, ADD PRIMARY KEY (hostname, state_time)
DROP INDEX hostname ON statusengine_hostchecks
ALTER TABLE statusengine_hostchecks CHANGE hostname hostname VARCHAR(255) NOT NULL, CHANGE state state SMALLINT UNSIGNED DEFAULT 0, CHANGE timeout timeout SMALLINT UNSIGNED DEFAULT 0, CHANGE current_check_attempt current_check_attempt SMALLINT UNSIGNED DEFAULT 0, CHANGE max_check_attempts max_check_attempts SMALLINT UNSIGNED DEFAULT 0, ADD PRIMARY KEY (hostname, start_time)
ALTER TABLE statusengine_hoststatus CHANGE current_state current_state SMALLINT UNSIGNED DEFAULT 0, CHANGE current_check_attempt current_check_attempt SMALLINT UNSIGNED DEFAULT 0, CHANGE max_check_attempts max_check_attempts SMALLINT UNSIGNED DEFAULT 0, CHANGE last_hard_state last_hard_state SMALLINT UNSIGNED DEFAULT 0, CHANGE acknowledgement_type acknowledgement_type SMALLINT UNSIGNED DEFAULT 0, CHANGE scheduled_downtime_depth scheduled_downtime_depth SMALLINT UNSIGNED DEFAULT 0
ALTER TABLE statusengine_logentries ADD id BIGINT UNSIGNED AUTO_INCREMENT NOT NULL, ADD PRIMARY KEY (id)
ALTER TABLE statusengine_service_acknowledgements CHANGE state state SMALLINT UNSIGNED DEFAULT 0, CHANGE acknowledgement_type acknowledgement_type SMALLINT UNSIGNED DEFAULT 0
ALTER TABLE statusengine_service_notifications CHANGE state state SMALLINT UNSIGNED DEFAULT 0, CHANGE reason_type reason_type SMALLINT UNSIGNED DEFAULT 0
DROP INDEX servicename_time ON statusengine_service_statehistory
DROP INDEX host_servicename_time ON statusengine_service_statehistory
ALTER TABLE statusengine_service_statehistory CHANGE hostname hostname VARCHAR(255) NOT NULL, CHANGE service_description service_description VARCHAR(255) NOT NULL, CHANGE state state SMALLINT UNSIGNED DEFAULT 0, CHANGE current_check_attempt current_check_attempt SMALLINT UNSIGNED DEFAULT 0, CHANGE max_check_attempts max_check_attempts SMALLINT UNSIGNED DEFAULT 0, CHANGE last_state last_state SMALLINT UNSIGNED DEFAULT 0, CHANGE last_hard_state last_hard_state SMALLINT UNSIGNED DEFAULT 0, ADD PRIMARY KEY (hostname, service_description, state_time)
DROP INDEX servicename ON statusengine_servicechecks
ALTER TABLE statusengine_servicechecks CHANGE hostname hostname VARCHAR(255) NOT NULL, CHANGE service_description service_description VARCHAR(255) NOT NULL, CHANGE state state SMALLINT UNSIGNED DEFAULT 0, CHANGE timeout timeout SMALLINT UNSIGNED DEFAULT 0, CHANGE current_check_attempt current_check_attempt SMALLINT UNSIGNED DEFAULT 0, CHANGE max_check_attempts max_check_attempts SMALLINT UNSIGNED DEFAULT 0, ADD PRIMARY KEY (hostname, service_description, start_time)
ALTER TABLE statusengine_servicestatus CHANGE current_state current_state SMALLINT UNSIGNED DEFAULT 0, CHANGE current_check_attempt current_check_attempt SMALLINT UNSIGNED DEFAULT 0, CHANGE max_check_attempts max_check_attempts SMALLINT UNSIGNED DEFAULT 0, CHANGE last_hard_state last_hard_state SMALLINT UNSIGNED DEFAULT 0, CHANGE scheduled_downtime_depth scheduled_downtime_depth SMALLINT UNSIGNED DEFAULT 0
No modifications where done to database!!!

```
